### PR TITLE
Enabling direct reporting on MADlib's website

### DIFF
--- a/download.html
+++ b/download.html
@@ -45,6 +45,16 @@
 		<div class="container section">
 			<div class="row">
 				<div class="span4">
+					<h2>Release Integrity</h2>
+				</div>
+				<div class="span8">
+                                <p>You must <a href="https://www.apache.org/info/verification.html">verify</a> the integrity of the downloaded files. We provide OpenPGP signatures for every release file. This signature should be matched against the <a href="https://www.apache.org/dist/incubator/madlib/KEYS">KEYS file</a> which contains the OpenPGP keys of MADlib's Release Managers. We also provide MD5 and SHA-512 checksums for every release file. After you download the file, you should calculate a checksum for your download, and make sure it is the same as ours.
+				</div>
+			</div>
+		</div>
+		<div class="container section">
+			<div class="row">
+				<div class="span4">
 					<h2>Current Release</h2>
 				</div>
 				<div class="span8">
@@ -56,9 +66,14 @@
 					<p class="no-y-space"><strong>Latest stable release:</strong></p>
 
 					<ul>
-						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'v1.11-incubating.tar.gz']);" href="https://dist.apache.org/repos/dist/release/incubator/madlib/1.11-incubating/">Source code tar.gz</a></li>
-						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.11-Linux.rpm']);" href="https://dist.apache.org/repos/dist/release/incubator/madlib/1.11-incubating/">Linux</a> — CentOS / Red Hat 5 and higher (64 bit).  For all supported platforms.</li>
-			            <li><a href="https://dist.apache.org/repos/dist/release/incubator/madlib/1.11-incubating/" onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.11-Darwin.dmg']);">Mac OS X</a> — OS 10.6 and higher.  For PostgreSQL 9.5 and 9.6.</li>
+						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'v1.11-incubating.tar.gz']);" href="http://apache.org/dyn/closer.cgi?filename=incubator/madlib/1.11-incubating/apache-madlib-1.11-incubating-src.tar.gz&action=download">Source code tar.gz</a> (<a href="https://www.apache.org/dist/incubator/madlib/1.11-incubating/apache-madlib-1.11-incubating-src.tar.gz.asc">pgp</a>, <a href="https://www.apache.org/dist/incubator/madlib/1.11-incubating/apache-madlib-1.11-incubating-src.tar.gz.md5">md5</a>, <a href="https://www.apache.org/dist/incubator/madlib/1.11-incubating/apache-madlib-1.11-incubating-src.tar.gz.sha512">sha512</a>)
+                                                </li>
+						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.11-Linux.rpm']);" href="http://apache.org/dyn/closer.cgi?filename=incubator/madlib/1.11-incubating/apache-madlib-1.11-incubating-bin-Linux.rpm&action=download">Linux</a> (<a href="https://www.apache.org/dist/incubator/madlib/1.11-incubating/apache-madlib-1.11-incubating-bin-Linux.rpm.asc">pgp</a>, <a href="https://www.apache.org/dist/incubator/madlib/1.11-incubating/apache-madlib-1.11-incubating-bin-Linux.rpm.md5">md5</a>, <a href="https://www.apache.org/dist/incubator/madlib/1.11-incubating/apache-madlib-1.11-incubating-bin-Linux.rpm.sha512">sha512</a>)
+ — CentOS / Red Hat 5 and higher (64 bit).  For all supported platforms.
+                                                </li>
+			                         <li><a href="http://apache.org/dyn/closer.cgi?filename=incubator/madlib/1.11-incubating/apache-madlib-1.11-incubating-bin-Darwin.dmg&action=download" onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.11-Darwin.dmg']);">Mac OS X</a> (<a href="https://www.apache.org/dist/incubator/madlib/1.11-incubating/apache-madlib-1.11-incubating-bin-Darwin.dmg.asc">pgp</a>, <a href="https://www.apache.org/dist/incubator/madlib/1.11-incubating/apache-madlib-1.11-incubating-bin-Darwin.dmg.md5">md5</a>, <a href="https://www.apache.org/dist/incubator/madlib/1.11-incubating/apache-madlib-1.11-incubating-bin-Darwin.dmg.sha512">sha512</a>)
+ — OS 10.6 and higher.  For PostgreSQL 9.5 and 9.6.
+                                                </li>
 					</ul>
 				</div>
 			</div>
@@ -93,9 +108,9 @@
 					<p class="no-y-space"><strong>Release artifacts:</strong></p>
 
 					<ul>
-						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'v1.10-incubating.tar.gz']);" href="https://dist.apache.org/repos/dist/release/incubator/madlib/1.10.0-incubating/">Source code tar.gz</a></li>
-						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.10-Linux.rpm']);" href="https://dist.apache.org/repos/dist/release/incubator/madlib/1.10.0-incubating/">Linux</a> — CentOS / Red Hat 5 and higher (64 bit).  For all supported platforms.</li>
-			            <li><a href="https://dist.apache.org/repos/dist/release/incubator/madlib/1.10.0-incubating/" onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.10-Darwin.dmg']);">Mac OS X</a> — OS 10.6 and higher.  For PostgreSQL 9.5 and 9.6.</li>
+						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'v1.10-incubating.tar.gz']);" href="https://archive.apache.org/dist/incubator/madlib/1.10.0-incubating/">Source code tar.gz</a></li>
+						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.10-Linux.rpm']);" href="https://archive.apache.org/dist/incubator/madlib/1.10.0-incubating/">Linux</a> — CentOS / Red Hat 5 and higher (64 bit).  For all supported platforms.</li>
+			            <li><a href="https://archive.apache.org/dist/incubator/madlib/1.10.0-incubating/" onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.10-Darwin.dmg']);">Mac OS X</a> — OS 10.6 and higher.  For PostgreSQL 9.5 and 9.6.</li>
 					</ul>
 
 					<h3>v1.9.1</h3>
@@ -106,9 +121,9 @@
 					<p class="no-y-space"><strong>Release artifacts:</strong></p>
 
 					<ul>
-						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'v1.9.1-incubating.tar.gz']);" href="https://dist.apache.org/repos/dist/release/incubator/madlib/1.9.1-incubating/">Source code tar.gz</a></li>
-						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.9.1-Linux.rpm']);" href="https://dist.apache.org/repos/dist/release/incubator/madlib/1.9.1-incubating/">Linux</a> — CentOS / Red Hat 5 and higher (64 bit).  For all supported platforms.</li>
-			            <li><a href="https://dist.apache.org/repos/dist/release/incubator/madlib/1.9.1-incubating/" onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.9.1-Darwin.dmg']);">Mac OS X</a> — OS 10.6 and higher.  For PostgreSQL 9.4 and 9.5.</li>
+						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'v1.9.1-incubating.tar.gz']);" href="https://archive.apache.org/dist/incubator/madlib/1.9.1-incubating/">Source code tar.gz</a></li>
+						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.9.1-Linux.rpm']);" href="https://archive.apache.org/dist/incubator/madlib/1.9.1-incubating/">Linux</a> — CentOS / Red Hat 5 and higher (64 bit).  For all supported platforms.</li>
+			            <li><a href="https://archive.apache.org/dist/incubator/madlib/1.9.1-incubating/" onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.9.1-Darwin.dmg']);">Mac OS X</a> — OS 10.6 and higher.  For PostgreSQL 9.4 and 9.5.</li>
 					</ul>
 
 					<h3>v1.9</h3>
@@ -119,9 +134,9 @@
 					<p class="no-y-space"><strong>Release artifacts:</strong></p>
 
 					<ul>
-						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'v1.9-incubating.tar.gz']);" href="https://dist.apache.org/repos/dist/release/incubator/madlib/1.9-incubating/">Source code tar.gz</a></li>
-						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.9-Linux.rpm']);" href="https://dist.apache.org/repos/dist/release/incubator/madlib/1.9-incubating/">Linux</a> — CentOS / Red Hat 5 and higher (64 bit).  For all supported platforms.</li>
-			            <li><a href="https://dist.apache.org/repos/dist/release/incubator/madlib/1.9-incubating/" onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.9-Darwin.dmg']);">Mac OS X</a> — OS 10.6 and higher.  For PostgreSQL 9.4.</li>
+						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'v1.9-incubating.tar.gz']);" href="https://archive.apache.org/dist/incubator/madlib/1.9-incubating/">Source code tar.gz</a></li>
+						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.9-Linux.rpm']);" href="https://archive.apache.org/dist/incubator/madlib/1.9-incubating/">Linux</a> — CentOS / Red Hat 5 and higher (64 bit).  For all supported platforms.</li>
+			            <li><a href="https://archive.apache.org/dist/incubator/madlib/1.9-incubating/" onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.9-Darwin.dmg']);">Mac OS X</a> — OS 10.6 and higher.  For PostgreSQL 9.4.</li>
 					</ul>
 
 				</div>
@@ -138,7 +153,7 @@
 					<p class="no-y-space"><strong>Release artifacts:</strong></p>
 
 					<ul>
-						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'v1.9alpha-incubating.tar.gz']);" href="https://dist.apache.org/repos/dist/release/incubator/madlib/1.9alpha-incubating/">tar.gz</a></li>
+						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'v1.9alpha-incubating.tar.gz']);" href="https://archive.apache.org/dist/incubator/madlib/1.9alpha-incubating/">tar.gz</a></li>
 					</ul>
 				</div>
 			</div>


### PR DESCRIPTION
This enables the vertical widget on the right hand side of the website similar to what's available on CouchDB's website http://couchdb.apache.org/
