### PR TITLE
Add notebook for deep learning with keras

### DIFF
--- a/community-artifacts/deep_learning_gpu_demo.ipynb
+++ b/community-artifacts/deep_learning_gpu_demo.ipynb
@@ -1,0 +1,598 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GPU-Enabled Deep Learning with Greenplum using Tensorflow and Keras"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This iPython notebook walks the user through training and testing a deep learning model built with tensorflow and keras in Greenplum 5.X. The model is constructed within a plpython function in SQL, and this function is invoked through a SQL UDF (with the training/test data passed in)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Connect to the host GCP machine, which is GPU-enabled, and interface with this machine using psql"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext sql"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Greenplum Database 5.4.0 on GCP with NVIDIA Tesla K80 GPU (demo machine)\n",
+    "greenplum_gpu_db = \"postgresql://<username>@<ip>:<postgres_port>/<dbname>\"\n",
+    "%sql $greenplum_gpu_db"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load MNIST dataset into SQL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash -s $greenplum_gpu_db\n",
+    "\n",
+    "# Unzip data files\n",
+    "gunzip -c ../data/mnist_train.sql.gz > ../data/mnist_train.sql\n",
+    "gunzip -c ../data/mnist_test.sql.gz > ../data/mnist_test.sql\n",
+    "\n",
+    "# Greenplum load\n",
+    "psql $1 -f ../data/mnist_train.sql\n",
+    "psql $1 -f ../data/mnist_test.sql"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "SELECT * FROM mnist_train LIMIT 2;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define a SQL aggregate function that inserts the MNIST dataset (stored within a SQL table) into the Python general dictionary (GD), which is accessible within plpython functions. This allows the model training/testing algorithms to access the training and test MNIST data. The GD is initially empty."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "drop function if exists add_data_to_GD(\n",
+    "    text[],\n",
+    "    text,\n",
+    "    text[],\n",
+    "    float8[],\n",
+    "    float8\n",
+    ") cascade;\n",
+    "create or replace function add_data_to_GD(\n",
+    "    key text[],  -- \n",
+    "    table_name text, -- table name\n",
+    "    col_names text[], -- name of the features column and the dependent variable column\n",
+    "    features float8[], -- independent variables (as array)\n",
+    "    label float8 -- dependent variable column\n",
+    ")\n",
+    "returns text[]\n",
+    "as\n",
+    "$$\n",
+    "    col_names_key = table_name+'_col_names'\n",
+    "    if col_names_key not in GD:\n",
+    "        GD[col_names_key] = col_names\n",
+    "        \n",
+    "    if not key:\n",
+    "        gd_feature_key = table_name + '_' + col_names[0]\n",
+    "        GD[gd_feature_key] = [features]\n",
+    "        gd_label_key = table_name + '_' + col_names[1]\n",
+    "        GD[gd_label_key] = [label]\n",
+    "        return [gd_feature_key, gd_label_key]\n",
+    "    else:\n",
+    "        GD[table_name + '_' + col_names[0]].append(features)\n",
+    "        GD[table_name + '_' + col_names[1]].append(label)\n",
+    "        return key\n",
+    "$$language plpythonu;\n",
+    "\n",
+    "drop aggregate if exists add_data_to_GD_agg( \n",
+    "    text, -- table name\n",
+    "    text[], -- header (feature names)\n",
+    "    float8[], -- features (feature values),\n",
+    "    float8 -- labels\n",
+    ") cascade;\n",
+    "create aggregate add_data_to_GD_agg(\n",
+    "        text, -- table name\n",
+    "        text[], -- header (feature names)\n",
+    "        float8[], -- features (feature values),\n",
+    "        float8 -- labels\n",
+    "    )\n",
+    "(\n",
+    "    SFUNC = add_data_to_GD,\n",
+    "    STYPE = text[]\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "create or replace function viewGD()\n",
+    "returns text\n",
+    "as\n",
+    "$$\n",
+    "   return GD\n",
+    "$$language plpythonu;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "create or replace function clearGD()\n",
+    "returns void\n",
+    "as\n",
+    "$$\n",
+    "   GD['iris_data_col_names'] = []\n",
+    "   GD['iris_data_x'] = []\n",
+    "   GD['iris_data_y'] = []\n",
+    "$$language plpythonu;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "select viewGD();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "create or replace function usingGPU()\n",
+    "returns text\n",
+    "as\n",
+    "$$\n",
+    "   import tensorflow as tf \n",
+    "   sess = tf.Session(config=tf.ConfigProto(log_device_placement=True))\n",
+    "   return sess\n",
+    "$$language plpythonu;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql \n",
+    "SELECT usingGPU();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define the plpython function keras_train, callable in SQL, to train a keras deep learning model with the provided MNIST training set. The model created is a simple dense neural network with 1 hidden layer, a softmax output, and dropout regularization. The function returns the trained model in serialized format, outputing a text array that contains serialized strings of the model's architecture and weights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "create or replace function keras_train(train_keys text[],  test_keys text[], use_cpu_only boolean)\n",
+    "returns text[]\n",
+    "as\n",
+    "$$\n",
+    "    import os\n",
+    "    import tensorflow as tf\n",
+    "    plpy.info(\"Start\")\n",
+    "    plpy.info(os.popen('hostname').read().strip())\n",
+    "    \n",
+    "    import keras\n",
+    "    from keras.models import Sequential\n",
+    "    from keras.layers import Dense, Dropout, Activation\n",
+    "    from keras.optimizers import RMSprop\n",
+    "    import pandas as pd\n",
+    "    import numpy as np\n",
+    "    import pickle\n",
+    "    \n",
+    "    batch_size = 128\n",
+    "    num_classes = 10\n",
+    "    epochs = 5\n",
+    "    feature_key = train_keys[0]\n",
+    "    label_key = train_keys[1]\n",
+    "    x_train = np.asarray(GD[feature_key], dtype=np.float32)\n",
+    "    x_train /= 255\n",
+    "    \n",
+    "    y_train = np.asarray(GD[label_key], dtype=np.float32)\n",
+    "    y_train = keras.utils.to_categorical(y_train, num_classes)\n",
+    "\n",
+    "    test_feature_key = test_keys[0]\n",
+    "    test_label_key = test_keys[1]\n",
+    "\n",
+    "    x_test = np.asarray(GD[test_feature_key], dtype=np.float32)\n",
+    "    x_test /= 255\n",
+    "    \n",
+    "    y_test = np.asarray(GD[test_label_key], dtype=np.float32)\n",
+    "    y_test = keras.utils.to_categorical(y_test)\n",
+    "    \n",
+    "    model = Sequential()\n",
+    "    model.add(Dense(512, activation='relu', input_shape=(784,)))\n",
+    "    model.add(Dropout(0.2))\n",
+    "    model.add(Dense(512, activation='relu'))\n",
+    "    model.add(Dropout(0.2))\n",
+    "    model.add(Dense(num_classes, activation='softmax'))\n",
+    "\n",
+    "    model.compile(loss='categorical_crossentropy',\n",
+    "              optimizer=RMSprop(),\n",
+    "              metrics=['accuracy'])\n",
+    "\n",
+    "    if use_cpu_only: \n",
+    "        import os\n",
+    "        os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # to disable GPU\n",
+    "        device_flag = '/cpu:0'\n",
+    "    else: \n",
+    "        device_flag = '/gpu:0'\n",
+    "        \n",
+    "    with tf.device(device_flag):\n",
+    "        \n",
+    "        # Debugging if it actually works only on cpu \n",
+    "        # Below plpy.info should only include \"/device:CPU:0\" if USE_CPU_ONLY=True\n",
+    "        from tensorflow.python.client import device_lib\n",
+    "        plpy.info(device_lib.list_local_devices())\n",
+    "        \n",
+    "        history = model.fit(x_train, y_train,\n",
+    "                            batch_size=batch_size,\n",
+    "                            epochs=epochs,\n",
+    "                            verbose=1\n",
+    "                           )\n",
+    "\n",
+    "        model_arch_json = model.to_json()\n",
+    "        model_serialized_weights = pickle.dumps(model.get_weights(), protocol=0)\n",
+    "        result = [model_arch_json, model_serialized_weights]\n",
+    "\n",
+    "    plpy.info(\"Finished training\")\n",
+    "    return result\n",
+    "    \n",
+    "$$language plpythonu IMMUTABLE;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Call this plpython function in SQL, inserting the training and test sets into the GD in order to pass in the data. Store the output (the serialized model) into a SQL table, to be used during the prediction phase of this module. Note: if tensorflow is mapped to tensorflow-gpu and CUDA/cuDNN 9.0 are installed, the system automatically uses the available NVIDIA Tesla K80 GPU for training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "\n",
+    "-- Use GPU\n",
+    "drop table if exists results_gpu_train, test_table;\n",
+    "create table results_gpu_train (\n",
+    "    model_architecture text,\n",
+    "    model_weights text\n",
+    ");\n",
+    "create table test_table as (\n",
+    "    select keras_train(stacked_train_keys, stacked_test_keys, false)\n",
+    "        from\n",
+    "            (select add_data_to_GD_agg('mnist_train', ARRAY['x', 'y'], x, y) \n",
+    "                    as stacked_train_keys\n",
+    "            from\n",
+    "                mnist_train\n",
+    "            )q1,\n",
+    "            (select add_data_to_GD_agg('mnist_test', ARRAY['x', 'y'], x, y)\n",
+    "                    as stacked_test_keys\n",
+    "            from \n",
+    "                mnist_test\n",
+    "            )q2);\n",
+    "insert into results_gpu_train values (\n",
+    "    (select keras_train[1] FROM test_table),\n",
+    "    (select keras_train[2] FROM test_table));\n",
+    "SELECT model_architecture FROM results_gpu_train;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "\n",
+    "-- Use CPU\n",
+    "drop table if exists results_cpu_train, test_table;\n",
+    "create table results_cpu_train (\n",
+    "    model_architecture text,\n",
+    "    model_weights text\n",
+    ");\n",
+    "create table test_table as (\n",
+    "    select keras_train(stacked_train_keys, stacked_test_keys, true)\n",
+    "        from\n",
+    "            (select add_data_to_GD_agg('mnist_train', ARRAY['x', 'y'], x, y) \n",
+    "                    as stacked_train_keys\n",
+    "            from\n",
+    "                mnist_train\n",
+    "            )q1,\n",
+    "            (select add_data_to_GD_agg('mnist_test', ARRAY['x', 'y'], x, y)\n",
+    "                    as stacked_test_keys\n",
+    "            from \n",
+    "                mnist_test\n",
+    "            )q2);\n",
+    "insert into results_cpu_train values (\n",
+    "    (select keras_train[1] FROM test_table),\n",
+    "    (select keras_train[2] FROM test_table));\n",
+    "SELECT model_architecture FROM results_cpu_train;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "sess = tf.Session(config=tf.ConfigProto(log_device_placement=True))\n",
+    "print(tf.device('/gpu:0'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define the plpython function keras_predict, callable in SQL, to predict the labels of the test set data using the trained keras model (computed and returned in the previous cell). The function first de-serializes and recreates the  keras model. Then, it uses the MNIST test set to perform prediction. The function returns the loss and accuracy of its predictions, as specified in keras_predict_type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "DROP TYPE IF EXISTS keras_predict_type CASCADE;\n",
+    "CREATE TYPE keras_predict_type\n",
+    "AS\n",
+    "(\n",
+    "    hostname text, -- hostname on which the model was built\n",
+    "    loss text, -- intercepts\n",
+    "    accuracy text -- training data fit\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "create or replace function keras_predict(model_data text, test_keys text[])\n",
+    "returns keras_predict_type\n",
+    "as\n",
+    "$$\n",
+    "    import os\n",
+    "\n",
+    "    plpy.info(\"Start\")\n",
+    "    plpy.info(os.popen('hostname').read().strip())\n",
+    "    \n",
+    "    import keras\n",
+    "    from keras.models import model_from_json\n",
+    "    from keras.models import Sequential\n",
+    "    from keras.layers import Dense, Dropout, Activation\n",
+    "    from keras.optimizers import RMSprop, Adam\n",
+    "    import pandas as pd\n",
+    "    import numpy as np\n",
+    "    import pickle\n",
+    "    \n",
+    "    batch_size = 128\n",
+    "    num_classes = 10\n",
+    "    \n",
+    "    df1 = pd.DataFrame(GD[model_data], columns=GD['results_train'+'_header'])\n",
+    "    model_architecture = df1[GD['results_train'+'_header'][0]].values.tolist()\n",
+    "    model_weights = df1[GD['results_train'+'_header'][1]].values.tolist()\n",
+    "    \n",
+    "    test_feature_key = test_keys[0]\n",
+    "    test_label_key = test_keys[1]\n",
+    "    x_test=np.asarray(GD[test_feature_key], dtype=np.float32)\n",
+    "    x_test /= 255\n",
+    "    y_test = np.asarray(GD[test_label_key], dtype=np.float32)\n",
+    "    y_test = keras.utils.to_categorical(y_test)\n",
+    "    \n",
+    "    model = model_from_json(model_architecture[0])\n",
+    "    model_weights = pickle.loads(model_weights[0])\n",
+    "    model.set_weights(model_weights)\n",
+    "    \n",
+    "    model.compile(loss='categorical_crossentropy',\n",
+    "              optimizer=Adam(),\n",
+    "              metrics=['accuracy'])\n",
+    "    \n",
+    "    score = model.evaluate(x_test, y_test, verbose=0)\n",
+    "    result = [os.popen('hostname').read().strip(),\n",
+    "             \"Test loss: {0}\".format(score[0]),\n",
+    "             \"Test accuracy: {0}\".format(score[1])]\n",
+    "    return result\n",
+    "    \n",
+    "$$language plpythonu IMMUTABLE;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This user-defined aggregate serves the same purpose as the previous add_data_to_GD UDA, but specifically accepts inputs of type text rather than float8."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "drop function if exists add_model_to_GD(\n",
+    "    text,\n",
+    "    text,\n",
+    "    text[],\n",
+    "    text,\n",
+    "    text\n",
+    ") cascade;\n",
+    "create or replace function add_model_to_GD(\n",
+    "    key text,\n",
+    "    table_name text, -- table name\n",
+    "    header text[], -- name of the features column and the dependent variable column\n",
+    "    features text, -- independent variables (as array)\n",
+    "    label text -- dependent variable column\n",
+    ")\n",
+    "returns text\n",
+    "as\n",
+    "$$\n",
+    "    header_key = table_name+'_header'\n",
+    "    if header_key not in GD:\n",
+    "        GD[header_key] = header\n",
+    "    if not key:\n",
+    "        gd_key = table_name\n",
+    "        GD[gd_key] = [[features, label]]\n",
+    "        return gd_key\n",
+    "    else:\n",
+    "        GD[key].append([features, label])\n",
+    "        return key\n",
+    "$$language plpythonu;\n",
+    "\n",
+    "drop aggregate if exists add_model_to_GD_agg(\n",
+    "    text, -- table name\n",
+    "    text[], -- header (feature names)\n",
+    "    text, -- features (feature values),\n",
+    "    text -- labels\n",
+    ") cascade;\n",
+    "create aggregate add_model_to_GD_agg(\n",
+    "        text, -- table name\n",
+    "        text[], -- header (feature names)\n",
+    "        text, -- features (feature values),\n",
+    "        text -- labels\n",
+    "    )\n",
+    "(\n",
+    "    SFUNC = add_model_to_GD,\n",
+    "    STYPE = text -- the key in GD used to hold the data across calls\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Call the previously-defined keras_predict function in SQL, passing in the serialized model and test data via GD. Outputs the loss and accuracy data into a SQL table. Uses the NVIDIA Tesla K80 GPU for prediction if tensorflow_gpu is configured."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "select keras_predict(model_data, stacked_test_keys) as results_test\n",
+    "from\n",
+    "    (select add_model_to_GD_agg('results_train', ARRAY['model_architecture', 'model_weights'], model_architecture, model_weights)\n",
+    "        as model_data\n",
+    "        from\n",
+    "            results_train\n",
+    "        )q1,\n",
+    "    (select add_data_to_GD_agg('mnist_test', ARRAY['x', 'y'], x, y)\n",
+    "        as stacked_test_keys\n",
+    "        from \n",
+    "            mnist_test\n",
+    "        )q2;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('-------------------------------------------------------------------------------------------------------------------')\n",
+    "print('End of deep learning GPU spike')\n",
+    "print('-------------------------------------------------------------------------------------------------------------------')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
This iPython notebook walks the user through training and testing a deep
learning model built with tensorflow and keras in Greenplum 5.X. The
model is constructed within a plpython function in SQL, and this
function is invoked through a SQL UDF (with the training/test data
passed in).

Co-authored-by: Arvind Sridhar <asridhar@pivotal.io>
Co-authored-by: Rahul Iyer <riyer@pivotal.io>
Co-authored-by: Orhan Kislal <okislal@pivotal.io>
Co-authored-by: Jingyi Mei <jmei@pivotal.io>
Co-authored-by: Domino Valdano <dvaldano@pivotal.io>
Co-authored-by: Nandish Jayaram <njayaram@pivotal.io>