### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Ignore generated code files
+*.so
+*.o
+*.pyc
+
+ # Meta data of Mac OS X's Finder.app
+.DS_Store
+
+# tags
+/cscope.files
+/refresh_index.sh
+/tags*
+.tags*
+
+# project files
+.predictive
+.Rhistory
+eproject.cfg
+*.project.vim


### PR DESCRIPTION
Adding `.gitignore`, mostly for the `.pyc` files that get generated, each time madlib_image_loader.py gets run.