### PR TITLE
Image loader support for numeric arrays

### DIFF
--- a/community-artifacts/Deep-learning/Load-images-v1.ipynb
+++ b/community-artifacts/Deep-learning/Load-images-v1.ipynb
@@ -16,7 +16,9 @@
     "\n",
     "<a href=\"#fetch_numpy\">2. Fetch images then load NumPy array into table</a>\n",
     "\n",
-    "<a href=\"#file_system\">3. Load from file system into table</a>"
+    "<a href=\"#file_system\">3. Load from file system into table</a>\n",
+    "\n",
+    "<a href=\"#fetch_numpy_label\">4. Fetch images then load NumPy array into table with label datatype as INT</a>"
    ]
   },
   {
@@ -674,6 +676,314 @@
    "source": [
     "%%sql\n",
     "SELECT COUNT(*) FROM cifar_10_train_data_filesystem;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"fetch_numpy_label\"></a>\n",
+    "# 4. Fetch images then load NumPy array into table with label datatype as INT\n",
+    "\n",
+    "<em>iloader.load_dataset_from_np(data_x, data_y, table_name, append=False, label_datatype= 'int')</em>\n",
+    "\n",
+    "- <em>data_x</em> contains image data in np.array format\n",
+    "\n",
+    "\n",
+    "- <em>data_y</em> is a 1D np.array of the image categories (labels).\n",
+    "\n",
+    "\n",
+    "- If the user passes a <em>table_name</em> while creating ImageLoader object, it will be used for all further calls to load_dataset_from_np.  It can be changed by passing it as a parameter during the actual call to load_dataset_from_np, and if so future calls will load to that table name instead.  This avoids needing to pass the table_name again every time, but also allows it to be changed at any time.\n",
+    "\n",
+    "\n",
+    "- If the user passes a <em>label_datatype</em> is the datatype of the image categories (labels) column in the output table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load dataset into np array\n",
+    "(x_train, y_train), (x_test, y_test) = cifar10.load_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done.\n",
+      "MainProcess: Connected to madlib db.\n",
+      "Executing: CREATE TABLE cifar_10_train_data_int (id SERIAL, x REAL[], y int)\n",
+      "CREATE TABLE\n",
+      "Created table cifar_10_train_data_int in madlib db\n",
+      "Spawning 5 workers...\n",
+      "Initializing PoolWorker-11 [pid 42137]\n",
+      "PoolWorker-11: Created temporary directory /tmp/madlib_8Pc3rPCJJL\n",
+      "Initializing PoolWorker-12 [pid 42138]\n",
+      "PoolWorker-12: Created temporary directory /tmp/madlib_QOyefNO7bi\n",
+      "Initializing PoolWorker-13 [pid 42139]\n",
+      "Initializing PoolWorker-14 [pid 42140]\n",
+      "PoolWorker-13: Created temporary directory /tmp/madlib_iFiR9zT8Za\n",
+      "PoolWorker-14: Created temporary directory /tmp/madlib_EAo5JPfg55\n",
+      "Initializing PoolWorker-15 [pid 42142]\n",
+      "PoolWorker-11: Connected to madlib db.\n",
+      "PoolWorker-15: Created temporary directory /tmp/madlib_AjkjHXX3lr\n",
+      "PoolWorker-12: Connected to madlib db.\n",
+      "PoolWorker-13: Connected to madlib db.\n",
+      "PoolWorker-14: Connected to madlib db.\n",
+      "PoolWorker-15: Connected to madlib db.\n",
+      "PoolWorker-11: Wrote 1000 images to /tmp/madlib_8Pc3rPCJJL/cifar_10_train_data_int0000.tmp\n",
+      "PoolWorker-12: Wrote 1000 images to /tmp/madlib_QOyefNO7bi/cifar_10_train_data_int0000.tmp\n",
+      "PoolWorker-13: Wrote 1000 images to /tmp/madlib_iFiR9zT8Za/cifar_10_train_data_int0000.tmp\n",
+      "PoolWorker-14: Wrote 1000 images to /tmp/madlib_EAo5JPfg55/cifar_10_train_data_int0000.tmp\n",
+      "PoolWorker-15: Wrote 1000 images to /tmp/madlib_AjkjHXX3lr/cifar_10_train_data_int0000.tmp\n",
+      "PoolWorker-11: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-12: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-13: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-14: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-15: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-11: Wrote 1000 images to /tmp/madlib_8Pc3rPCJJL/cifar_10_train_data_int0001.tmp\n",
+      "PoolWorker-12: Wrote 1000 images to /tmp/madlib_QOyefNO7bi/cifar_10_train_data_int0001.tmp\n",
+      "PoolWorker-13: Wrote 1000 images to /tmp/madlib_iFiR9zT8Za/cifar_10_train_data_int0001.tmp\n",
+      "PoolWorker-14: Wrote 1000 images to /tmp/madlib_EAo5JPfg55/cifar_10_train_data_int0001.tmp\n",
+      "PoolWorker-15: Wrote 1000 images to /tmp/madlib_AjkjHXX3lr/cifar_10_train_data_int0001.tmp\n",
+      "PoolWorker-11: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-12: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-13: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-14: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-15: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-11: Wrote 1000 images to /tmp/madlib_8Pc3rPCJJL/cifar_10_train_data_int0002.tmp\n",
+      "PoolWorker-12: Wrote 1000 images to /tmp/madlib_QOyefNO7bi/cifar_10_train_data_int0002.tmp\n",
+      "PoolWorker-11: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-13: Wrote 1000 images to /tmp/madlib_iFiR9zT8Za/cifar_10_train_data_int0002.tmp\n",
+      "PoolWorker-15: Wrote 1000 images to /tmp/madlib_AjkjHXX3lr/cifar_10_train_data_int0002.tmp\n",
+      "PoolWorker-14: Wrote 1000 images to /tmp/madlib_EAo5JPfg55/cifar_10_train_data_int0002.tmp\n",
+      "PoolWorker-12: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-13: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-15: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-14: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-11: Wrote 1000 images to /tmp/madlib_8Pc3rPCJJL/cifar_10_train_data_int0003.tmp\n",
+      "PoolWorker-11: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-12: Wrote 1000 images to /tmp/madlib_QOyefNO7bi/cifar_10_train_data_int0003.tmp\n",
+      "PoolWorker-13: Wrote 1000 images to /tmp/madlib_iFiR9zT8Za/cifar_10_train_data_int0003.tmp\n",
+      "PoolWorker-15: Wrote 1000 images to /tmp/madlib_AjkjHXX3lr/cifar_10_train_data_int0003.tmp\n",
+      "PoolWorker-14: Wrote 1000 images to /tmp/madlib_EAo5JPfg55/cifar_10_train_data_int0003.tmp\n",
+      "PoolWorker-12: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-11: Wrote 1000 images to /tmp/madlib_8Pc3rPCJJL/cifar_10_train_data_int0004.tmp\n",
+      "PoolWorker-13: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-15: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-14: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-11: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-12: Wrote 1000 images to /tmp/madlib_QOyefNO7bi/cifar_10_train_data_int0004.tmp\n",
+      "PoolWorker-13: Wrote 1000 images to /tmp/madlib_iFiR9zT8Za/cifar_10_train_data_int0004.tmp\n",
+      "PoolWorker-12: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-15: Wrote 1000 images to /tmp/madlib_AjkjHXX3lr/cifar_10_train_data_int0004.tmp\n",
+      "PoolWorker-14: Wrote 1000 images to /tmp/madlib_EAo5JPfg55/cifar_10_train_data_int0004.tmp\n",
+      "PoolWorker-11: Wrote 1000 images to /tmp/madlib_8Pc3rPCJJL/cifar_10_train_data_int0005.tmp\n",
+      "PoolWorker-13: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-15: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-12: Wrote 1000 images to /tmp/madlib_QOyefNO7bi/cifar_10_train_data_int0005.tmp\n",
+      "PoolWorker-14: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-11: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-12: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-13: Wrote 1000 images to /tmp/madlib_iFiR9zT8Za/cifar_10_train_data_int0005.tmp\n",
+      "PoolWorker-15: Wrote 1000 images to /tmp/madlib_AjkjHXX3lr/cifar_10_train_data_int0005.tmp\n",
+      "PoolWorker-14: Wrote 1000 images to /tmp/madlib_EAo5JPfg55/cifar_10_train_data_int0005.tmp\n",
+      "PoolWorker-11: Wrote 1000 images to /tmp/madlib_8Pc3rPCJJL/cifar_10_train_data_int0006.tmp\n",
+      "PoolWorker-12: Wrote 1000 images to /tmp/madlib_QOyefNO7bi/cifar_10_train_data_int0006.tmp\n",
+      "PoolWorker-13: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-15: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-14: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-11: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-12: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-13: Wrote 1000 images to /tmp/madlib_iFiR9zT8Za/cifar_10_train_data_int0006.tmp\n",
+      "PoolWorker-15: Wrote 1000 images to /tmp/madlib_AjkjHXX3lr/cifar_10_train_data_int0006.tmp\n",
+      "PoolWorker-13: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-14: Wrote 1000 images to /tmp/madlib_EAo5JPfg55/cifar_10_train_data_int0006.tmp\n",
+      "PoolWorker-11: Wrote 1000 images to /tmp/madlib_8Pc3rPCJJL/cifar_10_train_data_int0007.tmp\n",
+      "PoolWorker-15: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-12: Wrote 1000 images to /tmp/madlib_QOyefNO7bi/cifar_10_train_data_int0007.tmp\n",
+      "PoolWorker-14: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-11: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-12: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-13: Wrote 1000 images to /tmp/madlib_iFiR9zT8Za/cifar_10_train_data_int0007.tmp\n",
+      "PoolWorker-15: Wrote 1000 images to /tmp/madlib_AjkjHXX3lr/cifar_10_train_data_int0007.tmp\n",
+      "PoolWorker-13: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-15: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-14: Wrote 1000 images to /tmp/madlib_EAo5JPfg55/cifar_10_train_data_int0007.tmp\n",
+      "PoolWorker-11: Wrote 1000 images to /tmp/madlib_8Pc3rPCJJL/cifar_10_train_data_int0008.tmp\n",
+      "PoolWorker-12: Wrote 1000 images to /tmp/madlib_QOyefNO7bi/cifar_10_train_data_int0008.tmp\n",
+      "PoolWorker-13: Wrote 1000 images to /tmp/madlib_iFiR9zT8Za/cifar_10_train_data_int0008.tmp\n",
+      "PoolWorker-15: Wrote 1000 images to /tmp/madlib_AjkjHXX3lr/cifar_10_train_data_int0008.tmp\n",
+      "PoolWorker-14: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-11: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-12: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-13: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-15: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-14: Wrote 1000 images to /tmp/madlib_EAo5JPfg55/cifar_10_train_data_int0008.tmp\n",
+      "PoolWorker-11: Wrote 1000 images to /tmp/madlib_8Pc3rPCJJL/cifar_10_train_data_int0009.tmp\n",
+      "PoolWorker-12: Wrote 1000 images to /tmp/madlib_QOyefNO7bi/cifar_10_train_data_int0009.tmp\n",
+      "PoolWorker-14: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-11: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-12: Loaded 1000 images into cifar_10_train_data_int\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PoolWorker-11: Wrote 1000 images to /tmp/madlib_8Pc3rPCJJL/cifar_10_train_data_int0010.tmp\n",
+      "PoolWorker-12: Wrote 1000 images to /tmp/madlib_QOyefNO7bi/cifar_10_train_data_int0010.tmp\n",
+      "PoolWorker-11: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-12: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-11: Wrote 1000 images to /tmp/madlib_8Pc3rPCJJL/cifar_10_train_data_int0011.tmp\n",
+      "PoolWorker-11: Loaded 1000 images into cifar_10_train_data_int\n",
+      "PoolWorker-15: Removed temporary directory /tmp/madlib_AjkjHXX3lr\n",
+      "PoolWorker-14: Removed temporary directory /tmp/madlib_EAo5JPfg55\n",
+      "PoolWorker-12: Removed temporary directory /tmp/madlib_QOyefNO7bi\n",
+      "PoolWorker-11: Removed temporary directory /tmp/madlib_8Pc3rPCJJL\n",
+      "PoolWorker-13: Removed temporary directory /tmp/madlib_iFiR9zT8Za\n",
+      "Done!  Loaded 50000 images in 40.9305319786s\n",
+      "5 workers terminated.\n",
+      "MainProcess: Connected to madlib db.\n",
+      "Executing: CREATE TABLE cifar_10_test_data_int (id SERIAL, x REAL[], y int)\n",
+      "CREATE TABLE\n",
+      "Created table cifar_10_test_data_int in madlib db\n",
+      "Spawning 5 workers...\n",
+      "Initializing PoolWorker-16 [pid 42208]\n",
+      "PoolWorker-16: Created temporary directory /tmp/madlib_J8m9MJp916\n",
+      "Initializing PoolWorker-17 [pid 42209]\n",
+      "PoolWorker-17: Created temporary directory /tmp/madlib_jH7fmFz0Ku\n",
+      "Initializing PoolWorker-18 [pid 42210]\n",
+      "PoolWorker-18: Created temporary directory /tmp/madlib_lRPK3C5DIL\n",
+      "Initializing PoolWorker-19 [pid 42211]\n",
+      "PoolWorker-19: Created temporary directory /tmp/madlib_KkQlXdU0Vd\n",
+      "PoolWorker-16: Connected to madlib db.\n",
+      "PoolWorker-17: Connected to madlib db.\n",
+      "PoolWorker-18: Connected to madlib db.\n",
+      "Initializing PoolWorker-20 [pid 42215]\n",
+      "PoolWorker-20: Created temporary directory /tmp/madlib_RfyStrRruL\n",
+      "PoolWorker-19: Connected to madlib db.\n",
+      "PoolWorker-20: Connected to madlib db.\n",
+      "PoolWorker-16: Wrote 1000 images to /tmp/madlib_J8m9MJp916/cifar_10_test_data_int0000.tmp\n",
+      "PoolWorker-17: Wrote 1000 images to /tmp/madlib_jH7fmFz0Ku/cifar_10_test_data_int0000.tmp\n",
+      "PoolWorker-18: Wrote 1000 images to /tmp/madlib_lRPK3C5DIL/cifar_10_test_data_int0000.tmp\n",
+      "PoolWorker-19: Wrote 1000 images to /tmp/madlib_KkQlXdU0Vd/cifar_10_test_data_int0000.tmp\n",
+      "PoolWorker-20: Wrote 1000 images to /tmp/madlib_RfyStrRruL/cifar_10_test_data_int0000.tmp\n",
+      "PoolWorker-16: Loaded 1000 images into cifar_10_test_data_int\n",
+      "PoolWorker-20: Loaded 1000 images into cifar_10_test_data_int\n",
+      "PoolWorker-19: Loaded 1000 images into cifar_10_test_data_int\n",
+      "PoolWorker-17: Loaded 1000 images into cifar_10_test_data_int\n",
+      "PoolWorker-18: Loaded 1000 images into cifar_10_test_data_int\n",
+      "PoolWorker-16: Wrote 1000 images to /tmp/madlib_J8m9MJp916/cifar_10_test_data_int0001.tmp\n",
+      "PoolWorker-20: Wrote 1000 images to /tmp/madlib_RfyStrRruL/cifar_10_test_data_int0001.tmp\n",
+      "PoolWorker-19: Wrote 1000 images to /tmp/madlib_KkQlXdU0Vd/cifar_10_test_data_int0001.tmp\n",
+      "PoolWorker-17: Wrote 1000 images to /tmp/madlib_jH7fmFz0Ku/cifar_10_test_data_int0001.tmp\n",
+      "PoolWorker-18: Wrote 1000 images to /tmp/madlib_lRPK3C5DIL/cifar_10_test_data_int0001.tmp\n",
+      "PoolWorker-16: Loaded 1000 images into cifar_10_test_data_int\n",
+      "PoolWorker-19: Loaded 1000 images into cifar_10_test_data_int\n",
+      "PoolWorker-18: Loaded 1000 images into cifar_10_test_data_int\n",
+      "PoolWorker-17: Loaded 1000 images into cifar_10_test_data_int\n",
+      "PoolWorker-20: Loaded 1000 images into cifar_10_test_data_int\n",
+      "PoolWorker-16: Removed temporary directory /tmp/madlib_J8m9MJp916\n",
+      "PoolWorker-18: Removed temporary directory /tmp/madlib_lRPK3C5DIL\n",
+      "PoolWorker-17: Removed temporary directory /tmp/madlib_jH7fmFz0Ku\n",
+      "PoolWorker-20: Removed temporary directory /tmp/madlib_RfyStrRruL\n",
+      "PoolWorker-19: Removed temporary directory /tmp/madlib_KkQlXdU0Vd\n",
+      "Done!  Loaded 10000 images in 7.7835650444s\n",
+      "5 workers terminated.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%sql DROP TABLE IF EXISTS cifar_10_train_data_int, cifar_10_test_data_int;\n",
+    "\n",
+    "# Save images to temporary directories and load into database\n",
+    "iloader.load_dataset_from_np(x_train, y_train, 'cifar_10_train_data_int', append=False, label_datatype= 'int')\n",
+    "iloader.load_dataset_from_np(x_test, y_test, 'cifar_10_test_data_int', append=False, label_datatype= 'int')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 rows affected.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "    <tr>\n",
+       "        <th>count</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "        <td>50000</td>\n",
+       "    </tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "[(50000L,)]"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%sql\n",
+    "SELECT COUNT(*) FROM cifar_10_train_data_int;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 rows affected.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "    <tr>\n",
+       "        <th>count</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "        <td>10000</td>\n",
+       "    </tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "[(10000L,)]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%sql\n",
+    "SELECT COUNT(*) FROM cifar_10_test_data_int;"
    ]
   }
  ],


### PR DESCRIPTION
This PR adds support for numeric array labels when loading images. It also adds a new param `LABEL_DATATYPE` for the user to specify the SQL datatype of the label (for example: int, smallint, bigint etc), default being TEXT. Also, the user does not need to specify weather the dependent var column `y` (created in the table) is an array or not, the script figures that out based on the input.