### PR TITLE
Add .asf.yaml based on Apache's new website publishing procedures

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,8 @@
+# asf-staging branch will show up at https://madlib.staged.apache.org
+staging:
+  profile: ~
+  whoami:  asf-staging
+
+# asf-site branch will show up at https://madlib.apache.org
+publish:
+  whoami:  asf-site


### PR DESCRIPTION
Starting on July 1st, this file will be needed in order for any
new commits to asf-site to show up at https://madlib.apache.org

The second block adds a new feature, which allows us to test
changes in any branch without overwriting the official webpage,
by pushing it to asf-staging and viewing it at:
 https://madlib.staged.apache.oerg

Based on instructions here:
https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-WebSiteDeploymentServiceforGitRepositories