### PR TITLE
Adds missing %pip command

### DIFF
--- a/community-artifacts/Supervised-learning/Logistic-regression-v1.ipynb
+++ b/community-artifacts/Supervised-learning/Logistic-regression-v1.ipynb
@@ -8,6 +8,23 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Install package to get the `%sql`/`%%sql` commands:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install jupysql --quiet"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -870,9 +887,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "vscode",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -884,7 +901,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "3.10.8 (main, Nov  4 2022, 08:45:25) [Clang 12.0.0 ]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "311775ae6d8092fc5ad2ca66a4929014f2bf84f063ca6cd26574943ab663bae2"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi MADlib team!

I noticed that the Jupyter notebook examples are using `ipython-sql`. However there `pip install` command is missing, so the readers might get into trouble if they don't have the package installed. Furthermore, the package is no longer maintained so I'd recommend switching to [JupySQL](https://github.com/ploomber/jupysql), a fork I maintain.

Let me know if find this useful, I can open another PR and edit more examples!