### PR TITLE
Adhere to Apache WEBSITE NAVIGATION LINKS POLICY & Cleanup Download Page.

### DIFF
--- a/community.html
+++ b/community.html
@@ -28,6 +28,18 @@
 					<li id="menu-item-28" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-28"><a href="product.html">Product</a></li>
 					<li id="menu-item-25" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-25"><a title="Documentation" href="documentation.html">Documentation</a></li>
 					<li id="menu-item-24" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-24"><a href="community.html">Community</a></li>
+                                        <li class="li-asflinks">
+                                            <select id="latest-asflinks" name="latest-asflinks" class="select-asflinks">
+                                              <option value="">ASF Links</option>
+                                              <option value="https://www.apache.org/">ASF Homepage</option>
+                                              <option value="https://www.apache.org/events/current-event.html">Apache Events</option>
+                                              <option value="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct</option>
+                                              <option value="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</option>
+                                              <option value="https://www.apache.org/security/">Security</option>
+                                              <option value="https://www.apache.org/foundation/sponsorship.html">Sponsorship</option>
+                                              <option value="https://www.apache.org/foundation/thanks.html">Thanks</option>
+                                            </select>
+                                        </li>
 					<li id="menu-item-26" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-26 nav-button last"><a href="download.html">Download</a></li>
 					</ul>
 				</div>
@@ -224,7 +236,7 @@
           <br/>
           <br/>
         <p>
-          Copyright &copy; <script> var d = new Date();document.write(d.getFullYear());</script> <a href='https://www.apache.org/'>The Apache Software Foundation</a>
+          Copyright &copy; <script> var d = new Date();document.write(d.getFullYear());</script> <a href='https://www.apache.org/'>The Apache Software Foundation</a>, Licensed under the <a href='https://www.apache.org/licenses/LICENSE-2.0'>Apache License, Version 2.0.</a>
           <br>
           Apache, Apache MADlib, the Apache feather and the MADlib logo are trademarks of The Apache Software Foundation
         </p>

--- a/documentation.html
+++ b/documentation.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=1100">
+
 	<title>MADlib</title>
 
 	<script src="https://use.typekit.net/qbv8hok.js"></script>
@@ -28,6 +29,18 @@
 					<li id="menu-item-28" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-28"><a href="product.html">Product</a></li>
 					<li id="menu-item-25" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-25"><a title="Documentation" href="documentation.html">Documentation</a></li>
 					<li id="menu-item-24" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-24"><a href="community.html">Community</a></li>
+                                        <li class="li-asflinks">
+                                            <select id="latest-asflinks" name="latest-asflinks" class="select-asflinks">
+                                              <option value="">ASF Links</option>
+                                              <option value="https://www.apache.org/">ASF Homepage</option>
+                                              <option value="https://www.apache.org/events/current-event.html">Apache Events</option>
+                                              <option value="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct</option>
+                                              <option value="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</option>
+                                              <option value="https://www.apache.org/security/">Security</option>
+                                              <option value="https://www.apache.org/foundation/sponsorship.html">Sponsorship</option>
+                                              <option value="https://www.apache.org/foundation/thanks.html">Thanks</option>
+                                            </select>
+                                        </li>
 					<li id="menu-item-26" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-26 nav-button last"><a href="download.html">Download</a></li>
 					</ul>
 				</div>
@@ -205,7 +218,7 @@ jQuery(document).ready(function() {
 		  <br/>
 		  <br/>
 	    <p>
-	      Copyright &copy; <script>	var d = new Date();document.write(d.getFullYear());</script> <a href='https://www.apache.org/'>The Apache Software Foundation</a>
+	      Copyright &copy; <script> var d = new Date();document.write(d.getFullYear());</script> <a href='https://www.apache.org/'>The Apache Software Foundation</a>, Licensed under the <a href='https://www.apache.org/licenses/LICENSE-2.0'>Apache License, Version 2.0.</a>
 	      <br>
 	      Apache, Apache MADlib, the Apache feather and the MADlib logo are trademarks of The Apache Software Foundation
 	    </p>

--- a/download.html
+++ b/download.html
@@ -24,13 +24,23 @@
 				Home
 			</a>
 			<div class="nav">
-				<div class="menu-primary-navigation-container">
-					<ul id="menu-primary-navigation" class="menu">
-						<li id="menu-item-27" class="menu-item menu-item-type-post_type menu-item-object-page page_item page-item-18 current_page_item menu-item-27"><a href="index.html">Home</a></li>
-						<li id="menu-item-28" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-28"><a href="product.html">Product</a></li>
-						<li id="menu-item-25" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-25"><a title="Documentation" href="documentation.html">Documentation</a></li>
-						<li id="menu-item-24" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-24"><a href="community.html">Community</a></li>
-						<li id="menu-item-26" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-26 nav-button last"><a href="download.html">Download</a></li>
+				<div class="menu-primary-navigation-container"><ul id="menu-primary-navigation" class="menu"><li id="menu-item-27" class="menu-item menu-item-type-post_type menu-item-object-page page_item page-item-18 current_page_item menu-item-27"><a href="index.html">Home</a></li>
+					<li id="menu-item-28" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-28"><a href="product.html">Product</a></li>
+					<li id="menu-item-25" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-25"><a title="Documentation" href="documentation.html">Documentation</a></li>
+					<li id="menu-item-24" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-24"><a href="community.html">Community</a></li>
+                                        <li class="li-asflinks">
+                                            <select id="latest-asflinks" name="latest-asflinks" class="select-asflinks">
+                                              <option value="">ASF Links</option>
+                                              <option value="https://www.apache.org/">ASF Homepage</option>
+                                              <option value="https://www.apache.org/events/current-event.html">Apache Events</option>
+                                              <option value="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct</option>
+                                              <option value="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</option>
+                                              <option value="https://www.apache.org/security/">Security</option>
+                                              <option value="https://www.apache.org/foundation/sponsorship.html">Sponsorship</option>
+                                              <option value="https://www.apache.org/foundation/thanks.html">Thanks</option>
+                                            </select>
+                                        </li>
+					<li id="menu-item-26" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-26 nav-button last"><a href="download.html">Download</a></li>
 					</ul>
 				</div>
 			</div>
@@ -426,7 +436,7 @@
 		  <br/>
 		  <br/>
 	    <p>
-	      Copyright &copy; <script>	var d = new Date();document.write(d.getFullYear());</script> <a href='https://www.apache.org/'>The Apache Software Foundation</a>
+	      Copyright &copy; <script> var d = new Date();document.write(d.getFullYear());</script> <a href='https://www.apache.org/'>The Apache Software Foundation</a>, Licensed under the <a href='https://www.apache.org/licenses/LICENSE-2.0'>Apache License, Version 2.0.</a>
 	      <br>
 	      Apache, Apache MADlib, the Apache feather and the MADlib logo are trademarks of The Apache Software Foundation
 	    </p>

--- a/download.html
+++ b/download.html
@@ -85,27 +85,6 @@
 		<div class="container section">
 			<div class="row">
 				<div class="span4">
-					<h2>Current Release</h2>
-				</div>
-				<div class="span8">
-					<h3>v1.20.0</h3>
-					<h4>Source Code and Convenience Binaries</h4>
-
-					<p>MADlib<sup>&reg;</sup> source code is available from the Apache distribution site.</p>
-
-					<p class="no-y-space"><strong>Latest stable release:</strong></p>
-
-					<ul>
-						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.20.0-src.tar.gz']);"     href="https://dist.apache.org/repos/dist/release/madlib/1.20.0/apache-madlib-1.20.0-src.tar.gz">Source code tar.gz</a> (<a href="https://dist.apache.org/repos/dist/release/madlib/1.20.0/apache-madlib-1.20.0-src.tar.gz.asc">pgp</a>,     <a href="https://dist.apache.org/repos/dist/release/madlib/1.20.0/apache-madlib-1.20.0-src.tar.gz.sha512">sha512</a>) </li>
-
-						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.20.0-CentOS7.rpm']);"  href="https://dist.apache.org/repos/dist/release/madlib/1.20.0/apache-madlib-1.20.0-CentOS7.rpm">Linux</a>           (<a href="https://dist.apache.org/repos/dist/release/madlib/1.20.0/apache-madlib-1.20.0-CentOS7.rpm.asc">pgp</a>,  <a href="https://dist.apache.org/repos/dist/release/madlib/1.20.0/apache-madlib-1.20.0-CentOS7.rpm.sha512">sha512</a>) — CentOS7 / Red Hat 7 (64 bit). GPDB 5.x, GPDB 6.x, PostgreSQL 11.x and 12.x.</li>
-					</ul>
-				</div>
-			</div>
-		</div>
-		<div class="container section">
-			<div class="row">
-				<div class="span4">
 					<h2>MADlib <br/>Development Code</h2>
 				</div>
 				<div class="span8">
@@ -125,12 +104,28 @@
 					<h2>Previous Apache Releases</h2>
 				</div>
 				<div class="span8">
+
+
+
+					<h3>v1.20.0</h3>
+					<h4>Source Code and Convenience Binaries</h4>
+
+					<p>MADlib<sup>&reg;</sup> source code is available from the Apache distribution site.</p>
+
+					<p class="no-y-space"><strong>Release artifacts:</strong></p>
+
+					<ul>
+						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.20.0-src.tar.gz']);"     href="https://dist.apache.org/repos/dist/release/madlib/1.20.0/apache-madlib-1.20.0-src.tar.gz">Source code tar.gz</a> (<a href="https://dist.apache.org/repos/dist/release/madlib/1.20.0/apache-madlib-1.20.0-src.tar.gz.asc">pgp</a>,     <a href="https://dist.apache.org/repos/dist/release/madlib/1.20.0/apache-madlib-1.20.0-src.tar.gz.sha512">sha512</a>) </li>
+
+						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.20.0-CentOS7.rpm']);"  href="https://dist.apache.org/repos/dist/release/madlib/1.20.0/apache-madlib-1.20.0-CentOS7.rpm">Linux</a>           (<a href="https://dist.apache.org/repos/dist/release/madlib/1.20.0/apache-madlib-1.20.0-CentOS7.rpm.asc">pgp</a>,  <a href="https://dist.apache.org/repos/dist/release/madlib/1.20.0/apache-madlib-1.20.0-CentOS7.rpm.sha512">sha512</a>) — CentOS7 / Red Hat 7 (64 bit). GPDB 5.x, GPDB 6.x, PostgreSQL 11.x and 12.x.</li>
+					</ul>
+
 					<h3>v1.19.0</h3>
 					<h4>Source Code and Convenience Binaries</h4>
 
 					<p>MADlib<sup>&reg;</sup> source code is available from the Apache distribution site.</p>
 
-					<p class="no-y-space"><strong>Latest stable release:</strong></p>
+					<p class="no-y-space"><strong>Release artifacts:</strong></p>
 
 					<ul>
 						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.19.0-src.tar.gz']);"     href="https://dist.apache.org/repos/dist/release/madlib/1.19.0/apache-madlib-1.19.0-src.tar.gz">Source code tar.gz</a> (<a href="https://dist.apache.org/repos/dist/release/madlib/1.19.0/apache-madlib-1.19.0-src.tar.gz.asc">pgp</a>,     <a href="https://dist.apache.org/repos/dist/release/madlib/1.19.0/apache-madlib-1.19.0-src.tar.gz.sha512">sha512</a>) </li>
@@ -141,7 +136,7 @@
 
 					<p>MADlib<sup>&reg;</sup> source code and convenience binaries are available from the Apache distribution site.</p>
 
-					<p class="no-y-space"><strong>Latest stable release:</strong></p>
+					<p class="no-y-space"><strong>Release artifacts:</strong></p>
 
 					<ul>
 						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.18.0-src.tar.gz']);"     href="https://dist.apache.org/repos/dist/release/madlib/1.18.0/apache-madlib-1.18.0-src.tar.gz">Source code tar.gz</a> (<a href="https://dist.apache.org/repos/dist/release/madlib/1.18.0/apache-madlib-1.18.0-src.tar.gz.asc">pgp</a>,     <a href="https://dist.apache.org/repos/dist/release/madlib/1.18.0/apache-madlib-1.18.0-src.tar.gz.sha512">sha512</a>) </li>
@@ -160,7 +155,7 @@
 
 					<p>MADlib<sup>&reg;</sup> source code and convenience binaries are available from the Apache distribution site.</p>
 
-					<p class="no-y-space"><strong>Latest stable release:</strong></p>
+					<p class="no-y-space"><strong>Release artifacts:</strong></p>
 
 					<ul>
 						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.17.0-src.tar.gz']);"     href="https://archive.apache.org/dist/madlib/1.17.0/apache-madlib-1.17.0-src.tar.gz">Source code tar.gz</a> (<a href="https://archive.apache.org/dist/madlib/1.17.0/apache-madlib-1.17.0-src.tar.gz.asc">pgp</a>,     <a href="https://archive.apache.org/dist/madlib/1.17.0/apache-madlib-1.17.0-src.tar.gz.sha512">sha512</a>) </li>
@@ -179,7 +174,7 @@
 
 					<p>MADlib<sup>&reg;</sup> source code and convenience binaries are available from the Apache distribution site.</p>
 
-					<p class="no-y-space"><strong>Latest stable release:</strong></p>
+					<p class="no-y-space"><strong>Release artifacts:</strong></p>
 
 					<ul>
 						<li><a onclick="_gaq.push(['_trackEvent', 'Outbound Links', 'Click', 'madlib-1.16-src.tar.gz']);"     href="https://archive.apache.org/dist/madlib/1.16/apache-madlib-1.16-src.tar.gz">Source code tar.gz</a> (<a href="https://archive.apache.org/dist/madlib/1.16/apache-madlib-1.16-src.tar.gz.asc">pgp</a>,     <a href="https://archive.apache.org/dist/madlib/1.16/apache-madlib-1.16-src.tar.gz.sha512">sha512</a>) </li>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,18 @@
 					<li id="menu-item-28" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-28"><a href="product.html">Product</a></li>
 					<li id="menu-item-25" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-25"><a title="Documentation" href="documentation.html">Documentation</a></li>
 					<li id="menu-item-24" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-24"><a href="community.html">Community</a></li>
+                                        <li class="li-asflinks">
+                                            <select id="latest-asflinks" name="latest-asflinks" class="select-asflinks">
+                                              <option value="">ASF Links</option>
+                                              <option value="https://www.apache.org/">ASF Homepage</option>
+                                              <option value="https://www.apache.org/events/current-event.html">Apache Events</option>
+                                              <option value="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct</option>
+                                              <option value="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</option>
+                                              <option value="https://www.apache.org/security/">Security</option>
+                                              <option value="https://www.apache.org/foundation/sponsorship.html">Sponsorship</option>
+                                              <option value="https://www.apache.org/foundation/thanks.html">Thanks</option>
+                                            </select>
+                                        </li>
 					<li id="menu-item-26" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-26 nav-button last"><a href="download.html">Download</a></li>
 					</ul>
 				</div>
@@ -272,7 +284,7 @@
 		  <br/>
 		  <br/>
 	    <p>
-	      Copyright &copy; <script>	var d = new Date();document.write(d.getFullYear());</script> <a href='https://www.apache.org/'>The Apache Software Foundation</a>
+	      Copyright &copy; <script> var d = new Date();document.write(d.getFullYear());</script> <a href='https://www.apache.org/'>The Apache Software Foundation</a>, Licensed under the <a href='https://www.apache.org/licenses/LICENSE-2.0'>Apache License, Version 2.0.</a>
 	      <br>
 	      Apache, Apache MADlib, the Apache feather and the MADlib logo are trademarks of The Apache Software Foundation
 	    </p>

--- a/master.js
+++ b/master.js
@@ -43,6 +43,15 @@ init = {
 			}
 			return false;
 		});
+	},
+	asflinksSelect: function() {
+		jQuery('#latest-asflinks').on('change', function() {
+			var url = jQuery(this).val();
+			if (url) {
+				window.location = url;
+			}
+			return false;
+		});
 	}
 };
 

--- a/product.html
+++ b/product.html
@@ -28,6 +28,18 @@
 					<li id="menu-item-28" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-28"><a href="product.html">Product</a></li>
 					<li id="menu-item-25" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-25"><a title="Documentation" href="documentation.html">Documentation</a></li>
 					<li id="menu-item-24" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-24"><a href="community.html">Community</a></li>
+                                        <li class="li-asflinks">
+                                            <select id="latest-asflinks" name="latest-asflinks" class="select-asflinks">
+                                              <option value="">ASF Links</option>
+                                              <option value="https://www.apache.org/">ASF Homepage</option>
+                                              <option value="https://www.apache.org/events/current-event.html">Apache Events</option>
+                                              <option value="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct</option>
+                                              <option value="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</option>
+                                              <option value="https://www.apache.org/security/">Security</option>
+                                              <option value="https://www.apache.org/foundation/sponsorship.html">Sponsorship</option>
+                                              <option value="https://www.apache.org/foundation/thanks.html">Thanks</option>
+                                            </select>
+                                        </li>
 					<li id="menu-item-26" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-26 nav-button last"><a href="download.html">Download</a></li>
 					</ul>
 				</div>
@@ -230,7 +242,7 @@
 		  <br/>
 		  <br/>
 	    <p>
-	      Copyright &copy; <script>	var d = new Date();document.write(d.getFullYear());</script> <a href='https://www.apache.org/'>The Apache Software Foundation</a>
+	      Copyright &copy; <script> var d = new Date();document.write(d.getFullYear());</script> <a href='https://www.apache.org/'>The Apache Software Foundation</a>, Licensed under the <a href='https://www.apache.org/licenses/LICENSE-2.0'>Apache License, Version 2.0.</a>
 	      <br>
 	      Apache, Apache MADlib, the Apache feather and the MADlib logo are trademarks of The Apache Software Foundation
 	    </p>

--- a/style.css
+++ b/style.css
@@ -1256,9 +1256,52 @@ body {
   overflow: hidden;
   width: 175px;
 }
+
+.li-asflinks {
+  display: inline-block;
+  border: none
+  border-bottom: none
+  overflow: hidden;
+  background: #f15722;
+  color: white;
+}
+
+.select-asflinks {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  display: inline-block;
+  border: 1px solid #c5d7e0;
+  border-bottom: 2px solid #c5d7e0;
+  background: transparent;
+  overflow: hidden;
+  width: 175px;
+  border-top-width: 0px;
+  border-left-width: 0px;
+  border-bottom-width: 0px;
+  border-right-width: 0px;
+  color: #6f9db2;
+}
+
 .select-documentation.point-down:after {
   right: 6px;
 }
+
+.select-asflinks select {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  display: inline-block;
+  border: 1px solid #c5d7e0;
+  border-bottom: 2px solid #c5d7e0;
+  background: transparent;
+  overflow: hidden;
+  width: 175px;
+  border-top-width: 0px;
+  border-left-width: 0px;
+  border-bottom-width: 0px;
+  border-right-width: 0px;
+  color: #6f9db2;
+}
+
 .select-documentation select {
   -moz-appearance: none;
   -webkit-appearance: none;
@@ -1272,7 +1315,12 @@ body {
   text-overflow: "";
   width: 130%;
 }
+
 .select-documentation select:focus {
+  outline: none;
+}
+
+.select-asflinks select:focus {
   outline: none;
 }
 


### PR DESCRIPTION
Currently deployed to: https://madlib.staged.apache.org/

Adhere to Apache WEBSITE NAVIGATION LINKS POLICY
Correct Apache Project Website Checks identified with:
https://whimsy.apache.org/site/project/madlib

The following were previously reported as a critical issue:

 - Events
 - License
 - Thanks
 - Security
 - Sponsorship
 - Privacy

For reference, here are the Website Navigation Links Policy we should
adhere to:

https://www.apache.org/foundation/marks/pmcs.html#navigation

This commit includes:

* Add "ASF Links" navbar menu item with the following text and links

  - ASF Homepage - https://www.apache.org/
  - Apache Events - https://www.apache.org/events/current-event.html
  - Code of Conduct - https://www.apache.org/foundation/policies/conduct.html
  - Privacy Policy - https://privacy.apache.org/policies/privacy-policy-public.html
  - Security - https://www.apache.org/security/
  - Sponsorship - https://www.apache.org/foundation/sponsorship.html

* Update the "footer" of all main pages to include

  text: Licensed under the Apache License, Version 2.0.
  link: https://www.apache.org/licenses/LICENSE-2.0